### PR TITLE
Update links to talks

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -52,17 +52,17 @@ href="https://youtu.be/EkfqgQXfEv8">After the launch: the difficult teenage year
 <h1><a
 href="https://www.youtube.com/watch?v=M94Hg1mMGAg">How coding in the open can help you release faster</a></h1>
 <date>20th March 2018</date>
-<p>How coding in the open can help speed up all stages of the release cycle. Delivered at <a href="https://pipelineconf.info/">Pipeline conference</a>.</p>
+<p>How coding in the open can help speed up all stages of the release cycle. Delivered at <a href="https://learn.pipelineconf.info/">Pipeline conference</a>.</p>
 <p>Video, slides and a great sketchnote are in <a href="/jfdi/open-code-helps-you-release-faster.html">my write-up</a>.</p>
 
 <h1><a
-href="https://www.turingfest.com/sessions/coding-open-government/">Coding in the open in government</a></h1>
+href="https://www.turingfest.com/videos/anna-shipman/coding-open-government">Coding in the open in government</a></h1>
 <date>3rd August 2017</date>
 <p>What coding in the open means and its benefits to government and industry.
 Delivered at <a
-href="https://www.turingfest.com/sessions/coding-open-government/">Turing Fest</a>.</p>
+href="https://www.turingfest.com/">Turing Fest</a>.</p>
 
-<p>Video is <a href="https://www.turingfest.com/2017/engineering/anna-shipman?wvideo=0p810lpdqr">on their site</a> (you can skip the email request), and slides are on <a href="https://www.slideshare.net/annashipman/coding-in-the-open-in-government-78530680">SlideShare</a>.</p>
+<p>Video is <a href="https://www.turingfest.com/videos/anna-shipman/coding-open-government">on their site</a> (you have to register), and slides are on <a href="https://www.slideshare.net/annashipman/coding-in-the-open-in-government-78530680">SlideShare</a>.</p>
 <h1><a
 href="https://gotocon.com/berlin-2016/presentations/show_talk.jsp?oid=7984">Open sourcing government</a></h1>
 <date>14 November 2016</date>
@@ -87,21 +87,18 @@ government</a></h1>
 <p>I gave a keynote at VelocityEU about the work I've been leading at GDS on building a PaaS
 for government.</p>
 <a href="https://www.youtube.com/watch?v=OLOaq-Xf5zU">Video is on
-YouTube</a>, <a
-href="http://www.slideshare.net/annashipman/a-paas-for-government">slides are here</a> and the <a
-href="http://conferences.oreilly.com/velocity/devops-web-performance-eu-2015/public/schedule/detail/46814">abstract is on the Velocity site</a>.</p>
+YouTube</a> and the <a
+href="http://www.slideshare.net/annashipman/a-paas-for-government">slides are here</a>.</p>
 <h1><a
-href="https://www.ucisa.ac.uk/groups/ig/Events/2015/IG15/new_programme.aspx">Digital
+href="https://ucisa.mediasite.com/mediasite/Play/fac6d59c22664589a74d62bf4ec64d4e1d?catalog=df689fa652624fb08419197ae3afcc852 ">Digital
 infrastructure for the government</a></h1>
 <date>30 September 2015</date>
 <p>I delivered a talk at <a
-href="https://www.ucisa.ac.uk/groups/ig/Events/2015/IG15/new_programme.aspx">UCISA</a>,
+href="https://www.ucisa.ac.uk/">UCISA</a>,
 the conference for the Universities and Colleges Information Systems Association
 about the work I've been leading on investigating a
-PaaS for government. Slides are available from the <a
-href="https://www.ucisa.ac.uk/groups/ig/Events/2015/IG15/new_programme.aspx">programme
-page</a> and there is also a video which you can find on <a
-href="http://ucisa.mediasite.com/mediasite/Catalog/catalogs/mediasite-ig15">this
+PaaS for government. There is a video which you can find on <a
+href="https://ucisa.mediasite.com/mediasite/Play/fac6d59c22664589a74d62bf4ec64d4e1d?catalog=df689fa652624fb08419197ae3afcc8521">this
 page</a> (you may have to register).</p>
 <h1><a href="http://www.infoq.com/presentations/gov-uk-devops">Delivering GOV.UK: DevOps for the nation</a></h1>
 <date>04 March 2015</date>
@@ -111,15 +108,13 @@ and the slides are <a
 href="http://www.slideshare.net/annashipman/delivering-govuk-devops-for-the-nation">on
 Slideshare</a> There is also a nice write-up of it on <a
 href="http://www.infoq.com/news/2015/03/gds-uk-gov-devops">the InfoQ site</a>.
-It was listed as one of the <a
-href="http://blog.getcrane.com/five-key-decks-to-revisit-from-qcon-london">top 5
-presentations</a> from the event.</p>
+It was listed as one of the top 5 presentations (<b>edit:</b> sadly link is now dead) from the event.</p>
 <h1><a href="https://www.youtube.com/watch?v=KRMYr_Bw04g">Infrastructure as Code in Government</a></h1>
 <date>16 September 2014</date>
-<p>A talk about how we do infrastructure as code on <a href="https://www.gov.uk">GOV.UK</a> and my work on <a href="http://gds-operations.github.io/vcloud-tools"/>vCloud Tools</a>, our open-source tools for automating provisioning. <a href="https://www.youtube.com/watch?v=KRMYr_Bw04g">Video is here</a>, abstract is <a href="http://velocityconf.com/velocityny2014/public/schedule/detail/35839">on the Velocity site</a> and the slides are <a href="http://www.slideshare.net/annashipman/infra-as-code">on Slideshare</a>.
+<p>A talk about how we do infrastructure as code on <a href="https://www.gov.uk">GOV.UK</a> and my work on <a href="http://gds-operations.github.io/vcloud-tools"/>vCloud Tools</a>, our open-source tools for automating provisioning. <a href="https://www.youtube.com/watch?v=KRMYr_Bw04g">Video is here</a> and slides are <a href="http://www.slideshare.net/annashipman/infra-as-code">on Slideshare</a>.
 <h1>Automating Government</h1>
 <date>06 June 2014</date>
-<p>I gave a talk at the delightful <a href="http://lanyrd.com/2014/sotr/" target="_blank">Scotch on the Rocks</a> in Edinburgh on my work on <a href="https://github.com/gds-operations/vcloud-tools" target="_blank">vCloud Tools</a> – what we built, how we built it, some hard problems we faced and some tips on how to automate your own infrastructure. <a href="http://www.slideshare.net/annashipman/automating-government" target="_blank">Slides are here</a>.
+<p>I gave a talk at the delightful Scotch on the Rocks in Edinburgh (sadly, no longer running) on my work on <a href="https://github.com/gds-operations/vcloud-tools" target="_blank">vCloud Tools</a> – what we built, how we built it, some hard problems we faced and some tips on how to automate your own infrastructure. <a href="http://www.slideshare.net/annashipman/automating-government" target="_blank">Slides are here</a>.
 <h1><a href="http://www.youtube.com/watch?v=Q1qWzz6liK0" target="_blank">Craftsman Softwareship</a></h1>
 <date>12 November 2013</date>
 <p>I gave an Ignite talk based on my <a href="/jfdi/roof-bug-fixing.html">roof bug-fixing</a> blog post.</p><p><a href="http://www.youtube.com/watch?v=Q1qWzz6liK0" target="_blank">Watch it</a>.</p>
@@ -135,7 +130,7 @@ three different JavaScript visualisation libraries. I delivered this at <a href=
 
 <p><a href="http://www.slideshare.net/annashipman/data-visualisations-in-iavascript" target="_blank">Slides</a>, <a href="https://github.com/annashipman/data-visualisations-in-javascript" target="_blank">Code</a>.</p>
 
-<h1><a href="http://xpday-london.editme.com/WhenAgileMightNotBeTheBestSolution" target="_blank">When Agile Might Not Be The Best Solution</a></h1>
+<h1>When Agile Might Not Be The Best Solution</h1>
 <date>07 December 2009</date>
 <p>A talk outlining some contraindications for Agile adoption. I delivered this
 in 2009 at XPDay, one of the main pro-Agile conferences, and it was very popular!</p>


### PR DESCRIPTION
Prompted by something else I went through the links to my talks to see which ones are still actually links. Roughly split between still there, have moved, and now totally dead.

This updates:

Pipeline conference is no more but they’ve hosted all materials at https://learn.pipelineconf.info/
Turing Fest have moved the videos around again and you have to register which also silently signs you up for the mailing list without telling you...
Velocity no longer have the schedule/abstract available as far as I can see
UCISA page is gone but video is still there..!
Sadly the blog listing my talk as one of the top 5 at QCon has now defunct.
Scotch on the Rocks is no more and the site I’d linked to with a previous link is also no more.
The XPDay 2012 wiki is no more.

Leaving the currently dead SPA link pending discussions about what to do about the previous sites, currently ongoing.