### PR TITLE
Make sidebars consistent

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,4 +1,6 @@
 <ul>
+
+<h2>Writing about tech, leadership and tech leadership</h2>
 {% for post in site.posts %}
 <li><a href="{{post.url}}">{{ post.title}}</a>
 <date>{{ post.date | date_to_long_string }}</date></li>

--- a/jfdi.html
+++ b/jfdi.html
@@ -4,8 +4,6 @@
 {% include header.html page_name=" : JFDI" %}
 
 <div class="left-column">
-<h2>Writing about tech, leadership and tech leadership</h2>
-
     {% include sidebar.html %}
 </div>
 


### PR DESCRIPTION
I added the blog subtitle only to the JFDI page, so when you go into a post it disappears. This corrects that.