### PR TITLE
Stop youtube tracking all my visitors

### DIFF
--- a/_posts/2014-07-07-preparing-ignite-talk.md
+++ b/_posts/2014-07-07-preparing-ignite-talk.md
@@ -42,5 +42,5 @@ The format of Ignite talks is a good constraint to encourage creativity and I re
 When it was finished I'd made quite a few mistakes and missed out things I'd wanted to say, but on balance, I think it went pretty well. Judge for yourself.
 
 <div class="embedded">
-  <iframe src="//www.youtube.com/embed/Q1qWzz6liK0" frameborder="0" allowfullscreen></iframe>
+  <iframe src="//www.youtube-nocookie.com/embed/Q1qWzz6liK0" frameborder="0" allowfullscreen></iframe>
 </div>

--- a/_posts/2015-10-29-a-paas-for-government.md
+++ b/_posts/2015-10-29-a-paas-for-government.md
@@ -9,5 +9,5 @@ I gave a keynote at Velocity EU about the work I've been doing on a PaaS for
 government.
 
 <div class="embedded">
-  <iframe src="https://www.youtube.com/embed/OLOaq-Xf5zU" frameborder="0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube-nocookie.com/embed/OLOaq-Xf5zU" frameborder="0" allowfullscreen></iframe>
 </div>

--- a/_posts/2015-11-27-ops-a-devs-guide-video.md
+++ b/_posts/2015-11-27-ops-a-devs-guide-video.md
@@ -8,7 +8,7 @@ layout: blog_post
 Video from my FFconf talk *Operations: a developer's guide*.
 
 <div class="embedded">
-  <iframe src="https://www.youtube.com/embed/y6hbrS3DheU" frameborder="0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube-nocookie.com/embed/y6hbrS3DheU" frameborder="0" allowfullscreen></iframe>
 </div>
 
 [Slides and links in previous post](/jfdi/slides-from-ops-a-devs-guide.html).

--- a/_posts/2018-04-29-open-code-helps-you-release-faster.md
+++ b/_posts/2018-04-29-open-code-helps-you-release-faster.md
@@ -10,7 +10,7 @@ A few weeks ago I talked about how coding in the open can help you release faste
 ## Video (30 minutes)
 
 <div class="embedded">
-  <iframe src="https://www.youtube.com/embed/M94Hg1mMGAg" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+  <iframe src="https://www.youtube-nocookie.com/embed/M94Hg1mMGAg" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
 
 ## Slides

--- a/_posts/2019-08-10-after-the-launch.md
+++ b/_posts/2019-08-10-after-the-launch.md
@@ -14,7 +14,7 @@ I gave a talk about how you can get out of the difficult teenage years at Contin
 ## Video (30 minutes)
 
 <div class="embedded">
-  <iframe src="https://www.youtube.com/embed/EkfqgQXfEv8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe src="https://www.youtube-nocookie.com/embed/EkfqgQXfEv8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ## Slides

--- a/_posts/2020-07-08-tech-leadership-panel.md
+++ b/_posts/2020-07-08-tech-leadership-panel.md
@@ -16,5 +16,5 @@ We discussed three main areas:
 It was a really interesting discussion. You can watch it here:
 
 <div class="embedded">
-  <iframe src="https://www.youtube.com/embed/gWXYVOjb-tA" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe src="https://www.youtube-nocookie.com/embed/gWXYVOjb-tA" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>


### PR DESCRIPTION
There is now an option available when you embed a youtube video called "privacy-enhanced mode"; off by default, when you switch it on, youtube "won't store information about visitors on your website unless they play the video". I'm sorry?! They've been tracking all visitors to my site who haven't played the videos?! FFS