### PR TITLE
Do not have all blog posts on one page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages'
-gem "webrick", "~> 1.7"
+gem 'webrick', '~> 1.7'
+gem 'jekyll-archives'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,8 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
+    jekyll-archives (2.2.1)
+      jekyll (>= 3.6, < 5.0)
     jekyll-avatar (0.7.0)
       jekyll (>= 3.0, < 5.0)
     jekyll-coffeescript (1.1.1)
@@ -254,6 +256,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  jekyll-archives
   webrick (~> 1.7)
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -6,4 +6,7 @@ kramdown:
   input: GFM
   hard_wrap: false
 
+plugins:
+  - jekyll-archives
+
 permalink: /jfdi/:title.html

--- a/_includes/post_for_list.html
+++ b/_includes/post_for_list.html
@@ -1,0 +1,1 @@
+<li><a href="{{ post.url }}">{{ post.title }}</a> <date>{{ post.date | date_to_long_string }}</date></li>

--- a/_includes/posts_list.html
+++ b/_includes/posts_list.html
@@ -1,8 +1,11 @@
 <ul>
 
-<h2>All posts</h2>
-{% for post in site.posts %}
+<h2>Archive</h2>
+<a href="/archive.html">See all posts by date or category</a>.
+<h3>Recent posts</h3>
+{% for post in site.posts limit:10 %}
 <li><a href="{{post.url}}">{{ post.title}}</a>
 <date>{{ post.date | date_to_long_string }}</date></li>
 {% endfor %}
+More in the <a href="/archive.html">archive</a>.
 </ul>

--- a/_includes/tags_list.html
+++ b/_includes/tags_list.html
@@ -1,23 +1,23 @@
 {% for tag in site.tags %}
   {% if tag[0] == "Technology" %}
-    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
+    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{ tag[1]|size }}) /
   {% endif %}
 {% endfor %}
 
 {% for tag in site.tags %}
   {% if tag[0] == "Leadership" %}
-    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
+    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[1]|size}}) /
   {% endif %}
 {% endfor %}
 
 {% for tag in site.tags %}
   {% if tag[0] == "Strategy" %}
-    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
+    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[1]|size}}) /
   {% endif %}
 {% endfor %}
 
 {% for tag in site.tags %}
   {% if tag[0] != "Technology" and tag[0] != "Leadership" and tag[0] != "Strategy" %}
-    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
+    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[1]|size}}) /
   {% endif %}
 {% endfor %}

--- a/_includes/tags_list.html
+++ b/_includes/tags_list.html
@@ -1,0 +1,23 @@
+{% for tag in site.tags %}
+  {% if tag[0] == "Technology" %}
+    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
+  {% endif %}
+{% endfor %}
+
+{% for tag in site.tags %}
+  {% if tag[0] == "Leadership" %}
+    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
+  {% endif %}
+{% endfor %}
+
+{% for tag in site.tags %}
+  {% if tag[0] == "Strategy" %}
+    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
+  {% endif %}
+{% endfor %}
+
+{% for tag in site.tags %}
+  {% if tag[0] != "Technology" and tag[0] != "Leadership" and tag[0] != "Strategy" %}
+    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
+  {% endif %}
+{% endfor %}

--- a/archive.html
+++ b/archive.html
@@ -10,13 +10,14 @@
 
 <div class="right-column">
 
-<h2>Browse by category</h2>
+<h2>Browse by tag</h2>
 
     {% include tags_list.html %}
 
 <h2>Browse by date</h2>
 
-{% for post in site.posts %}
+  <div class="posts-list">
+  {% for post in site.posts %}
 
         {% capture year_of_current_post %}
         {{ post.date | date: "%Y" }}
@@ -30,8 +31,8 @@
         <h2>{{ year_of_current_post }}</h2>
         <ul>
         {% endif %}
-        <div id="{{ post.anchor_id }}" class="blog-post">
-          <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        <div id="{{ post.anchor_id }}">
+          <li><a href="{{ post.url }}">{{ post.title }}</a></li>
         </div>
         {% if forloop.last %}
         </ul>
@@ -44,8 +45,9 @@
         {% endif %}
         {% endif %}
 
-{% endfor %}
+  {% endfor %}
 
+  </div>
 </div>
 
 {% include footer.html %}

--- a/archive.html
+++ b/archive.html
@@ -12,7 +12,23 @@
 
 <h2>Browse by category</h2>
 
-<a href="#Technology">Technology</a> / <a href="#Leadership">Leadership</a> / <a href="#Strategy">Strategy</a> /
+{% for tag in site.tags %}
+  {% if tag[0] == "Technology" %}
+    <a href="#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
+  {% endif %}
+{% endfor %}
+
+{% for tag in site.tags %}
+  {% if tag[0] == "Leadership" %}
+    <a href="#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
+  {% endif %}
+{% endfor %}
+
+{% for tag in site.tags %}
+  {% if tag[0] == "Strategy" %}
+    <a href="#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
+  {% endif %}
+{% endfor %}
 
 {% for tag in site.tags %}
   {% if tag[0] != "Technology" and tag[0] != "Leadership" and tag[0] != "Strategy" %}

--- a/archive.html
+++ b/archive.html
@@ -14,25 +14,25 @@
 
 {% for tag in site.tags %}
   {% if tag[0] == "Technology" %}
-    <a href="#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
+    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
   {% endif %}
 {% endfor %}
 
 {% for tag in site.tags %}
   {% if tag[0] == "Leadership" %}
-    <a href="#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
+    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
   {% endif %}
 {% endfor %}
 
 {% for tag in site.tags %}
   {% if tag[0] == "Strategy" %}
-    <a href="#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
+    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
   {% endif %}
 {% endfor %}
 
 {% for tag in site.tags %}
   {% if tag[0] != "Technology" and tag[0] != "Leadership" and tag[0] != "Strategy" %}
-    <a href="#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
+    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
   {% endif %}
 {% endfor %}
 

--- a/archive.html
+++ b/archive.html
@@ -16,7 +16,7 @@
 
 {% for tag in site.tags %}
   {% if tag[0] != "Technology" and tag[0] != "Leadership" and tag[0] != "Strategy" %}
-    <a href="#{{tag[0]|slugize}}">{{tag[0]}}</a> /
+    <a href="#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
   {% endif %}
 {% endfor %}
 

--- a/archive.html
+++ b/archive.html
@@ -32,7 +32,7 @@
         <ul>
         {% endif %}
         <div id="{{ post.anchor_id }}">
-          <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+          {% include post_for_list.html %}
         </div>
         {% if forloop.last %}
         </ul>

--- a/archive.html
+++ b/archive.html
@@ -12,29 +12,7 @@
 
 <h2>Browse by category</h2>
 
-{% for tag in site.tags %}
-  {% if tag[0] == "Technology" %}
-    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
-  {% endif %}
-{% endfor %}
-
-{% for tag in site.tags %}
-  {% if tag[0] == "Leadership" %}
-    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
-  {% endif %}
-{% endfor %}
-
-{% for tag in site.tags %}
-  {% if tag[0] == "Strategy" %}
-    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
-  {% endif %}
-{% endfor %}
-
-{% for tag in site.tags %}
-  {% if tag[0] != "Technology" and tag[0] != "Leadership" and tag[0] != "Strategy" %}
-    <a href="/tags/html#{{tag[0]|slugize}}">{{tag[0]}}</a> ({{tag[0]|size}}) /
-  {% endif %}
-{% endfor %}
+    {% include tags_list.html %}
 
 <h2>Browse by date</h2>
 

--- a/archive.html
+++ b/archive.html
@@ -1,0 +1,58 @@
+---
+---
+
+{% include header.html page_name=" : Archive" %}
+
+<div class="left-column">
+    {% include bio_sidebar.html %}
+    {% include posts_list.html %}
+</div>
+
+<div class="right-column">
+
+<h2>Browse by category</h2>
+
+<a href="#Technology">Technology</a> / <a href="#Leadership">Leadership</a> / <a href="#Strategy">Strategy</a> /
+
+{% for tag in site.tags %}
+  {% if tag[0] != "Technology" and tag[0] != "Leadership" and tag[0] != "Strategy" %}
+    <a href="#{{tag[0]|slugize}}">{{tag[0]}}</a> /
+  {% endif %}
+{% endfor %}
+
+<h2>Browse by date</h2>
+
+{% for post in site.posts %}
+
+        {% capture year_of_current_post %}
+        {{ post.date | date: "%Y" }}
+        {% endcapture %}
+
+        {% capture year_of_previous_post_in_set %}
+        {{ site.posts[forloop.index].date | date: "%Y" }}
+        {% endcapture %}
+
+        {% if forloop.first %}
+        <h2>{{ year_of_current_post }}</h2>
+        <ul>
+        {% endif %}
+        <div id="{{ post.anchor_id }}" class="blog-post">
+          <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        </div>
+        {% if forloop.last %}
+        </ul>
+        {% else %}
+        {% if year_of_current_post != year_of_previous_post_in_set %}
+        </ul>
+
+        <h2>{{ year_of_previous_post_in_set }}</h2>
+        <ul>
+        {% endif %}
+        {% endif %}
+
+{% endfor %}
+
+</div>
+
+{% include footer.html %}
+

--- a/bio.html
+++ b/bio.html
@@ -12,7 +12,7 @@
 
 <p>She has been a software developer for nearly 20 years. Before working at the FT, she was a Technical Architect at the UK's <a href="https://gds.blog.gov.uk/about/">Government Digital Service</a> leading on Open Source, <a href="https://docs.cloud.service.gov.uk/">GOV.UK PaaS</a> and GOV.UK.</p>
 
-<p>She <a href="http://www.annashipman.co.uk/cv.html">speaks at conferences</a>, <a href="http://www.annashipman.co.uk/jfdi.html">blogs on her personal website</a>, <a href="https://twitter.com/annashipman/">tweets</a> and is always up for a game of pool.</p>
+<p>She <a href="http://www.annashipman.co.uk/speaking.html">speaks at conferences</a>, <a href="http://www.annashipman.co.uk/jfdi.html">blogs on her personal website</a>, <a href="https://twitter.com/annashipman/">tweets</a> and is always up for a game of pool.</p>
 </div>
 </div>
 

--- a/jfdi.html
+++ b/jfdi.html
@@ -10,7 +10,7 @@
 
 <div class="right-column">
 
-  {% for post in site.posts %}
+  {% for post in site.posts limit: 4 %}
     <div id="{{ post.anchor_id }}" class="blog-post">
       <h1><a href="{{post.url}}">{{ post.title}}</a></h1>
       <date>{{ post.date | date_to_long_string }}</date>

--- a/jfdi.html
+++ b/jfdi.html
@@ -25,7 +25,7 @@
         {{ post.content }}
     </div>
   {% endfor %}
-
+<h3>For more posts, see the <a href="/archive.html">archive</a>.</h3>
 </div>
 
 {% include footer.html %}

--- a/style.css
+++ b/style.css
@@ -165,6 +165,11 @@ p .pretty-code-sample {
     border-bottom: 1px dotted #333;
 }
 
+.posts-list a{
+    color: black;
+    font-weight: bold;
+}
+
 
 @media (min-width: 700px) {
   .left-column {

--- a/tags.html
+++ b/tags.html
@@ -15,12 +15,14 @@
 
     {% include tags_list.html %}
 
-{% for tag in site.tags %}
-  <h3><a id="{{ tag[0]}}">{{ tag[0] }}</a></h3>
-  <ul>
-    {% for post in tag[1] %}
-      <li><a href="{{ post.url }}">{{ post.title }}</a></li>
-    {% endfor %}
-  </ul>
-{% endfor %}
+  <div class="posts-list">
+  {% for tag in site.tags %}
+    <h3><a id="{{ tag[0]}}">{{ tag[0] }}</a></h3>
+      <ul>
+        {% for post in tag[1] %}
+          <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+        {% endfor %}
+      </ul>
+  {% endfor %}
+  </div>
 </div>

--- a/tags.html
+++ b/tags.html
@@ -13,13 +13,7 @@
 <div class="right-column">
 <h2>Tags</h2>
 
-<a href="#Technology">Technology</a> / <a href="#Leadership">Leadership</a> / <a href="#Strategy">Strategy</a> /
-
-{% for tag in site.tags %}
-  {% if tag[0] != "Technology" and tag[0] != "Leadership" and tag[0] != "Strategy" %}
-    <a href="#{{tag[0]|slugize}}">{{tag[0]}}</a> /
-  {% endif %}
-{% endfor %}
+    {% include tags_list.html %}
 
 {% for tag in site.tags %}
   <h3><a id="{{ tag[0]}}">{{ tag[0] }}</a></h3>

--- a/tags.html
+++ b/tags.html
@@ -20,7 +20,7 @@
     <h3><a id="{{ tag[0]}}">{{ tag[0] }}</a></h3>
       <ul>
         {% for post in tag[1] %}
-          <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+          {% include post_for_list.html %}
         {% endfor %}
       </ul>
   {% endfor %}


### PR DESCRIPTION
Until now, all blog posts were included on jfdi.html. I liked this because it meant I could search through them all; but it was becoming absurdly slow to load, the page was enormous.

This PR lists only the most recent 4 in full on the page, and only the most recent 10 in the sidebar, and adds an archive page which has a full list of posts by date and a link to the tags page with all posts by tag.

The styling is not amazing, but at least I can change it in one place at a time. I would also like to have each tag on a page rather than all in one, but I can't figure out how to automate creation of a page per tag right now (at the moment, just using a tag in a post creates it, and a link for it on the tags page, which is nice, so I'd want to recreate that if it were a page for each). Anyway, that is a story for another day.

It might also be nice to order the tags by number of posts automatically but again, that's for another day.

Also note that the style of the sidebar is different (it's not posts list) and the archive page is only linked to from within JFDI. Not sure if I should change both those things but first I'm going to deploy this to check it actually solves the presenting problem!

[This blog post](https://stuntbox.com/blog/2020/07/jekyll-archives-group-posts-by-year/#solution) was useful.