### PR TITLE
Convert relative links to absolute in atom feed

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -19,7 +19,13 @@
     <link href="https://www.annashipman.co.uk{{ post.url }}"/>
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>https://www.annashipman.co.uk{{ post.url }}</id>
-    <content type="html">{{ post.content | xml_escape }}</content>
+    {% assign content = post.content %}
+    {% capture href %}href="{{ site.url }}/{% endcapture %}
+    {% capture src %}src="{{ site.url }}/{% endcapture %}
+    {% capture converted_content %}
+      {{ content | replace: 'href="/', href | replace: 'src="/', src }}
+    {% endcapture %}
+    <content type="html">{{ converted_content | xml_escape }}</content>
   </entry>
   {% endfor %}
 


### PR DESCRIPTION
The mailing list uses the atom feed to send out the updates, but in the atom feed, and therefore the emails, relative links don't work. This affects both links and images. If you read atom in a web browser it works, but in the email it doesn't. This change replaces relative links with absolute ones just for the atom feed.