### PR TITLE
Style images for emails

### DIFF
--- a/_posts/2024-12-13-first-year-kooth.md
+++ b/_posts/2024-12-13-first-year-kooth.md
@@ -17,7 +17,7 @@ Another thing that really drew me to Kooth were the technical challenges. When I
 
 We rolled out Soluna at the beginning of 2024, and have spent this year adding features and improving on it. If you are in the US [you can download it here](https://solunaapp.com/). And if you are in the UK, hold tight, because one of the next big exciting technical challenges we have is bringing Soluna back to the UK.
 
-![Screenshots of the Soluna app. Main image is of an exercise: "choose up to six values to guide your self-discovery journey"](/img/soluna_screenshot.png)
+<img src="/img/soluna_screenshot.png" alt="Screenshots of the Soluna app. Main image is of an exercise: 'choose up to six values to guide your self-discovery journey'" style="max-width: 100%; height: auto; display: block; border: 0;">
 
 ## Kooth is a very inclusive and friendly place
 


### PR DESCRIPTION
The emails are generated from atom.xml which doesn't have styles and in any case email clients don't tend to read style sheets, so I will need to remember in future not to use markdown for images (or presumably anything else embedded like slides or video) and make sure it has at least `max-width: 100%`; hopefully this will stop the image appearing huge in emails in future.

This change won't make any difference to the email that's already been sent but might remind me to do this next time.